### PR TITLE
Change request_ids to be uuids.  requestId must be under 40 character…

### DIFF
--- a/lib/soteria/utilities.rb
+++ b/lib/soteria/utilities.rb
@@ -8,8 +8,7 @@ class Utilities
   # @param [String] prefix The prefix for the request ID. This should tell the user what the call is.
   # @return [String] A string that is the request ID for a call. The request ID is just used for debugging purposes.
   def self.get_request_id(prefix)
-    time = Time.new
-    prefix + '_' + time.strftime('%Y%m%d%H%M%S')
+    SecureRandom.uuid.delete('-')
   end
 
 


### PR DESCRIPTION
Change request_ids to be uuids.  requestId must be under 40 characters.  Using prefix+time can result in requestIds that are too long (i.e. authenticate_user_credential_20170118203).

I considered just shortening the prefixes, but the date string isn't necessarily unique if you're sending multiple requests per second
